### PR TITLE
LMB-#24: Use stdClass instead of object

### DIFF
--- a/enrollib.php
+++ b/enrollib.php
@@ -268,7 +268,7 @@ function enrol_lmb_drop_all_users($idnumber, $role = null, $original = false) {
             $enrolmod = new enrol_lmb_plugin();
 
             foreach ($enrols as $enrol) {
-                $enrolup = new object();
+                $enrolup = new stdClass();
 
                 $enrolup->succeeded = 0;
 


### PR DESCRIPTION
Use PHP standard class stdClass instead of class object.
In PHP 7.2 object is a reserved word and can't be a class name.