### PR TITLE
Select a parent for new categories

### DIFF
--- a/lang/en/enrol_lmb.php
+++ b/lang/en/enrol_lmb.php
@@ -118,6 +118,7 @@ $string['coursehiddennever'] = 'Never';
 $string['coursehiddencron'] = 'Based on cron setting';
 $string['coursehiddenalways'] = 'Always';
 $string['cathidden'] = 'Create new categories as hidden';
+$string['catnested'] = 'Nest new categories under the selected course';
 $string['forcecat'] = 'Force category on update';
 $string['usemoodlecoursesettings'] = 'Use Moodle default course settings';
 $string['computesections'] = 'Compute number of sections';
@@ -285,6 +286,7 @@ $string['categorytypehelp'] = 'This allows you select what categories you would 
 </ul>';
 $string['catselecthelp'] = '';
 $string['cathiddenhelp'] = 'Create new categories as hidden.';
+$string['catnestedhelp'] = 'When checked, new categories will be created within the selected category. If this option is left unchecked, categories will be created in the root space. This option has no effect when the \'Selected\' category option is used.';
 $string['forcecathelp'] = 'This option will cause the category to changed to the above setting whenever a LMB/Banner update occurs, even if it has been manually changed.';
 $string['usemoodlecoursesettingshelp'] = 'When creating a new course, use the default course setting options found in the Moodle admin settings, instead of the settings hard-coded in this module.';
 $string['computesectionshelp'] = 'Compute the number of sections/topics to display, based on the number of weeks in a course.';

--- a/lib.php
+++ b/lib.php
@@ -853,6 +853,18 @@ class enrol_lmb_plugin extends enrol_plugin {
                     $cat->visible = 1;
                 }
                 $cat->sortorder = 999;
+
+                if ($this->get_config('catnested')) {
+                    if ($this->get_config('catselect') > 0) {
+                        $cat->parent = $this->get_config('catselect');
+                    } else {
+                        $logline .= "category not selected:";
+                        $status = false;
+
+                        break; 
+                    }
+                }
+
                 if ($cat->id = $DB->insert_record('course_categories', $cat, true)) {
                     $lmbcat = new stdClass();
                     $lmbcat->categoryid = $cat->id;
@@ -978,6 +990,17 @@ class enrol_lmb_plugin extends enrol_plugin {
                 $cat->visible = 0;
             } else {
                 $cat->visible = 1;
+            }
+
+            if ($this->get_config('catnested')) {
+                if ($this->get_config('catselect') > 0) {
+                    $cat->parent = $this->get_config('catselect');
+                } else {
+                    $logline .= "category not selected:";
+                    $status = false;
+
+                    return false; 
+                }
             }
 
             $cat->sortorder = 999;

--- a/settings.php
+++ b/settings.php
@@ -203,9 +203,16 @@ if ($ADMIN->fulltree) {
     $settingslmb->add(new admin_setting_configselect('enrol_lmb/cattype', get_string('categorytype', 'enrol_lmb'),
             get_string('categorytypehelp', 'enrol_lmb'), 'term', $options));
 
+    
+
+    $moodleversion = $CFG->version;
+
+    if ($moodleversion >= 2018120300) { // Moodle 3.6 changed coursecat to core_course_category
+        $displaylist = \core_course_category::make_categories_list();
+    }
     // Check for coursecat::make_categories_list, new in 2.5.
     // Old make_categories_list() depricated in 2.5.
-    if (method_exists('coursecat', 'make_categories_list')) {
+    elseif (method_exists('coursecat', 'make_categories_list')) {
         $displaylist = coursecat::make_categories_list();
     } else {
         $displaylist = array();

--- a/settings.php
+++ b/settings.php
@@ -216,6 +216,9 @@ if ($ADMIN->fulltree) {
     $settingslmb->add(new admin_setting_configselect('enrol_lmb/catselect', get_string('catselect', 'enrol_lmb'),
             get_string('catselecthelp', 'enrol_lmb'), 1, $displaylist));
 
+    $settingslmb->add(new admin_setting_configcheckbox('enrol_lmb/catnested', get_string('catnested', 'enrol_lmb'),
+            get_string('catnestedhelp', 'enrol_lmb'), 0));
+
     $settingslmb->add(new admin_setting_configcheckbox('enrol_lmb/cathidden', get_string('cathidden', 'enrol_lmb'),
             get_string('cathiddenhelp', 'enrol_lmb'), 0));
 


### PR DESCRIPTION
New setting that creates new categories under a selected category instead of the top category.

Also added support for the new core_course_category class in 3.6 (that replaces coursecat).